### PR TITLE
LPD-97375 Test DB2 boolean template (TRUE/FALSE + boolean column)

### DIFF
--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/DB2DB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/DB2DB.java
@@ -689,10 +689,10 @@ public class DB2DB extends BaseDB {
 	}
 
 	private static final String[] _DB2 = {
-		"--", "1", "0", "'1970-01-01-00.00.00.000000'", "current timestamp",
-		" blob", " blob", " decimal(30, 16)", " smallint", " timestamp",
-		" double", " integer", " bigint", " varchar(4000)", " clob(2G)",
-		" varchar", " generated always as identity", "commit"
+		"--", "TRUE", "FALSE", "'1970-01-01-00.00.00.000000'",
+		"current timestamp", " blob", " blob", " decimal(30, 16)", " boolean",
+		" timestamp", " double", " integer", " bigint", " varchar(4000)",
+		" clob(2G)", " varchar", " generated always as identity", "commit"
 	};
 
 	private static final int _SQL_STRING_SIZE = 4000;


### PR DESCRIPTION
Experiment: change the DB2 template so `[$FALSE$]/[$TRUE$]` render as `FALSE/TRUE` and boolean columns are created as `BOOLEAN` instead of `SMALLINT`.

Base is H5 (5.6.7), so this run tests whether the template change **breaks DB2** across the service-builder suite — not the H7 fix.

Diff is a single file: `DB2DB.java` `_DB2` template.