### PR TITLE
LPD-101861 Never match when an arrayable IN finder value is empty

### DIFF
--- a/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/PermissionCheckFinderEntryTest.java
+++ b/modules/util/portal-tools-service-builder-test-test/src/testIntegration/java/com/liferay/portal/tools/service/builder/test/PermissionCheckFinderEntryTest.java
@@ -30,11 +30,15 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.RoleTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.transaction.Propagation;
+import com.liferay.portal.kernel.transaction.TransactionConfig;
+import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.tools.service.builder.test.model.PermissionCheckFinderEntry;
 import com.liferay.portal.tools.service.builder.test.service.PermissionCheckFinderEntryLocalService;
+import com.liferay.portal.tools.service.builder.test.service.persistence.PermissionCheckFinderEntryPersistence;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -78,6 +82,14 @@ public class PermissionCheckFinderEntryTest {
 			_group1.getGroupId(), _user.getUserId());
 		_permissionCheckFinderEntry3 = _addPermissionCheckFinderEntry(
 			_group2.getGroupId(), _user.getUserId());
+	}
+
+	@Test
+	public void testFilterFindByEmptyGroupIds() {
+		Assert.assertEquals(
+			Collections.emptyList(),
+			_permissionCheckFinderEntryLocalService.filterFindByGroupId(
+				new long[0]));
 	}
 
 	@Test
@@ -170,6 +182,30 @@ public class PermissionCheckFinderEntryTest {
 			Arrays.asList(
 				_permissionCheckFinderEntry2, _permissionCheckFinderEntry3),
 			Collections.singletonList(_permissionCheckFinderEntry2));
+	}
+
+	@Test
+	public void testFindByEmptyGroupIds() throws Throwable {
+		PermissionCheckFinderEntryPersistence
+			permissionCheckFinderEntryPersistence =
+				(PermissionCheckFinderEntryPersistence)
+					_permissionCheckFinderEntryLocalService.
+						getBasePersistence();
+
+		TransactionInvokerUtil.invoke(
+			_transactionConfig,
+			() -> {
+				Assert.assertEquals(
+					Collections.emptyList(),
+					permissionCheckFinderEntryPersistence.findByGroupId(
+						new long[0]));
+				Assert.assertEquals(
+					0,
+					permissionCheckFinderEntryPersistence.countByGroupId(
+						new long[0]));
+
+				return null;
+			});
 	}
 
 	private PermissionCheckFinderEntry _addPermissionCheckFinderEntry(
@@ -306,6 +342,10 @@ public class PermissionCheckFinderEntryTest {
 				expectedEntriesGroup1AndAdminGroup, _permissionedUser);
 		}
 	}
+
+	private static final TransactionConfig _transactionConfig =
+		TransactionConfig.Factory.create(
+			Propagation.REQUIRED, new Class<?>[] {Exception.class});
 
 	private long _adminGroupId;
 	private User _adminUser;

--- a/portal-kernel/src/com/liferay/portal/kernel/service/persistence/impl/ArrayableFinderColumn.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/persistence/impl/ArrayableFinderColumn.java
@@ -34,12 +34,18 @@ public class ArrayableFinderColumn<T extends BaseModel<T>>
 		_hqlInPrefix = StringBundler.concat(
 			"(", entityAlias, columnName, andOperator ? " NOT IN (" : " IN (");
 
+		_hqlNeverMatches = StringBundler.concat(
+			"(", entityAlias, columnName, " IN (NULL))");
+
 		if (Objects.equals(columnName, dbColumnName)) {
 			_sqlInPrefix = _hqlInPrefix;
+			_sqlNeverMatches = _hqlNeverMatches;
 		}
 		else {
 			_sqlInPrefix = StringUtil.replace(
 				_hqlInPrefix, columnName, dbColumnName);
+			_sqlNeverMatches = StringUtil.replace(
+				_hqlNeverMatches, columnName, dbColumnName);
 		}
 	}
 
@@ -75,7 +81,15 @@ public class ArrayableFinderColumn<T extends BaseModel<T>>
 		Object[] array = (Object[])normalizedValue;
 
 		if (array.length == 0) {
-			return "";
+			if (_andOperator) {
+				return "";
+			}
+
+			if (sqlQuery) {
+				return _sqlNeverMatches;
+			}
+
+			return _hqlNeverMatches;
 		}
 
 		if (type == Type.STRING) {
@@ -233,6 +247,8 @@ public class ArrayableFinderColumn<T extends BaseModel<T>>
 
 	private final boolean _andOperator;
 	private final String _hqlInPrefix;
+	private final String _hqlNeverMatches;
 	private final String _sqlInPrefix;
+	private final String _sqlNeverMatches;
 
 }

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/service/persistence/impl/ArrayableFinderColumnTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/service/persistence/impl/ArrayableFinderColumnTest.java
@@ -20,16 +20,50 @@ import org.junit.Test;
 public class ArrayableFinderColumnTest {
 
 	@Test
-	public void testEmptyArrayDropsConstraint() {
+	public void testEmptyArrayAndOperatorDropsConstraint() {
 		ArrayableFinderColumn<TestModel> arrayableFinderColumn = _newLongColumn(
-			false, entity -> 0L);
+			true, entity -> 0L);
 
 		Object normalizedValue = arrayableFinderColumn.normalizeValue(null);
 
 		Assert.assertEquals(
 			"", arrayableFinderColumn.getSqlFragment(normalizedValue, false));
 		Assert.assertEquals(
+			"", arrayableFinderColumn.getSqlFragment(normalizedValue, true));
+	}
+
+	@Test
+	public void testEmptyArrayNeverMatches() {
+		ArrayableFinderColumn<TestModel> arrayableFinderColumn = _newLongColumn(
+			false, entity -> 0L);
+
+		Object normalizedValue = arrayableFinderColumn.normalizeValue(null);
+
+		Assert.assertEquals(
+			"(t.col IN (NULL))",
+			arrayableFinderColumn.getSqlFragment(normalizedValue, false));
+		Assert.assertEquals(
+			"(t.col IN (NULL))",
+			arrayableFinderColumn.getSqlFragment(normalizedValue, true));
+		Assert.assertEquals(
 			"", arrayableFinderColumn.toFinderArg(normalizedValue));
+	}
+
+	@Test
+	public void testEmptyArrayNeverMatchesNative() {
+		ArrayableFinderColumn<TestModel> arrayableFinderColumn =
+			new ArrayableFinderColumn<>(
+				"t.", "active", "active_", FinderColumn.Type.BOOLEAN, "=",
+				false, true, true, entity -> true);
+
+		Object normalizedValue = arrayableFinderColumn.normalizeValue(null);
+
+		Assert.assertEquals(
+			"(t.active IN (NULL))",
+			arrayableFinderColumn.getSqlFragment(normalizedValue, false));
+		Assert.assertEquals(
+			"(t.active_ IN (NULL))",
+			arrayableFinderColumn.getSqlFragment(normalizedValue, true));
 	}
 
 	@Test
@@ -129,14 +163,15 @@ public class ArrayableFinderColumnTest {
 	}
 
 	@Test
-	public void testStringEmptyArrayDropsConstraint() {
+	public void testStringEmptyArrayNeverMatches() {
 		ArrayableFinderColumn<TestModel> arrayableFinderColumn =
 			_newStringColumn(false, true, false, entity -> "anything");
 
 		Object normalizedValue = arrayableFinderColumn.normalizeValue(null);
 
 		Assert.assertEquals(
-			"", arrayableFinderColumn.getSqlFragment(normalizedValue, false));
+			"(t.col IN (NULL))",
+			arrayableFinderColumn.getSqlFragment(normalizedValue, false));
 	}
 
 	@Test


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101861

CI-only pull request. Base is `h7_0803_only_Tina_change` so the suite runs on Hibernate 7.

## What Is Being Validated

`ArrayableFinderColumn.getSqlFragment` now returns `(<alias>.<column> IN (NULL))` instead of an empty string when an `arrayable-operator="OR"` column receives a zero length array. `IN (NULL)` evaluates to UNKNOWN, so the predicate never matches and the finder returns nothing instead of emitting a dangling `WHERE` followed by `ORDER BY`. An empty `NOT IN` set still returns an empty fragment, since excluding nothing is the correct behavior there.

The construct has no precedent anywhere in the repository, and the two HQL parsers are independent implementations — Hibernate 5 uses the hand written ANTLR2 grammar, Hibernate 7 uses the rewritten ANTLR4 and SQM stack. A pass on one says nothing about the other, so this run exists to prove the Hibernate 7 side. The native SQL variant reaches the database directly on the `filterFind` and `filterCount` paths, so the dialect coverage in the integration batches matters too.

## What To Look At

`PermissionCheckFinderEntryTest` — `testFilterFindByEmptyGroupIds` and `testFindByEmptyGroupIds`. Both must pass. A `QuerySyntaxException` or any `unexpected token` in the log means Hibernate 7 rejects `IN (NULL)` and this approach is dead.

Everything else in this build is expected to be dominated by the known pre-existing Hibernate 7 buckets on this base. Diff against a sibling build on the same base rather than reading the raw failure count.
